### PR TITLE
Fix Missing Service Definitions

### DIFF
--- a/src/DependencyInjection/Compiler/EventHandlerCompiler.php
+++ b/src/DependencyInjection/Compiler/EventHandlerCompiler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shapecode\Bundle\TwigTemplateEventBundle\DependencyInjection\Compiler;
 
-use Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManager;
+use Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManagerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;

--- a/src/DependencyInjection/Compiler/EventHandlerCompiler.php
+++ b/src/DependencyInjection/Compiler/EventHandlerCompiler.php
@@ -7,6 +7,7 @@ namespace Shapecode\Bundle\TwigTemplateEventBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManager;
 
 final class EventHandlerCompiler implements CompilerPassInterface
 {
@@ -15,7 +16,7 @@ final class EventHandlerCompiler implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        $manager = $container->getDefinition('shapecode_twig_template_event.handler_manager');
+        $manager = $container->getDefinition(HandlerManager::class);
         $tags    = $container->findTaggedServiceIds('shapecode_twig_template_event.handler');
 
         foreach ($tags as $id => $config) {

--- a/src/DependencyInjection/Compiler/EventHandlerCompiler.php
+++ b/src/DependencyInjection/Compiler/EventHandlerCompiler.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shapecode\Bundle\TwigTemplateEventBundle\DependencyInjection\Compiler;
 
+use Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManager;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManager;
 
 final class EventHandlerCompiler implements CompilerPassInterface
 {

--- a/src/DependencyInjection/Compiler/EventHandlerCompiler.php
+++ b/src/DependencyInjection/Compiler/EventHandlerCompiler.php
@@ -16,7 +16,7 @@ final class EventHandlerCompiler implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        $manager = $container->getDefinition(HandlerManager::class);
+        $manager = $container->findDefinition(HandlerManagerInterface::class);
         $tags    = $container->findTaggedServiceIds('shapecode_twig_template_event.handler');
 
         foreach ($tags as $id => $config) {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -8,6 +8,12 @@ services:
   Shapecode\Bundle\TwigTemplateEventBundle\Services\EventService: ~
   Shapecode\Bundle\TwigTemplateEventBundle\Twig\EventExtension: ~
   Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManager: ~
+  
+  # aliases
+  Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManagerInterface:
+    alias: Shapecode\Bundle\TwigTemplateEventBundle\Manager\HandlerManager
+  Shapecode\Bundle\TwigTemplateEventBundle\Services\EventServiceInterface:
+    alias: Shapecode\Bundle\TwigTemplateEventBundle\Services\EventService
 
   # handler
   Shapecode\Bundle\TwigTemplateEventBundle\Event\Handler\IncludeHandler:


### PR DESCRIPTION
Fix #3
Adds aliases of services as root interface for autowire Dependency Injection
Replace `shapecode_twig_template_event.handler_manager` service name string in favor of using FQCN service name